### PR TITLE
Implemented verification handlers

### DIFF
--- a/vsn-backend/features/experiment/endpoints.go
+++ b/vsn-backend/features/experiment/endpoints.go
@@ -1,65 +1,16 @@
 package experiment
 
 import (
-	"context"
-	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/seg491X-team36/vsn-backend/features/security"
 )
 
-type experimentHandler[Request, Response any] func(ctx context.Context, request Request) Response
-
-func postRequestWrapper[Request, Response any](
-	handler experimentHandler[Request, Response],
-) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		// read the request body
-		data, err := io.ReadAll(r.Body)
-		_ = r.Body.Close()
-
-		if err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		// unmarshall the request
-		var request Request
-		if err := json.Unmarshal(data, request); err != nil {
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-
-		// handle the request
-		response := handler(r.Context(), request)
-
-		// marshall the response
-		data, err = json.Marshal(response)
-		if err != nil {
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		// sucessful response
-		_, _ = w.Write(data)
-		w.WriteHeader(http.StatusOK)
-	}
-}
-
 type Endpoints struct {
 }
 
 func (e *Endpoints) Bind(r chi.Router) {
-	r.Post("/verification/email", postRequestWrapper(func(ctx context.Context, request *verificationEmailRequest) *verificationEmailResponse {
-		return &verificationEmailResponse{}
-	}))
-
-	r.Post("/verification/code", postRequestWrapper(func(ctx context.Context, request *verificationCodeRequest) *verificationCodeResponse {
-		return &verificationCodeResponse{}
-	}))
-
 	r.Route("/experiment", func(r chi.Router) {
 		r.Use(security.AuthMiddleware(nil)) // TODO
 		r.Post("/pending", func(w http.ResponseWriter, r *http.Request) {})

--- a/vsn-backend/features/experiment/verification_handlers.go
+++ b/vsn-backend/features/experiment/verification_handlers.go
@@ -1,0 +1,32 @@
+package experiment
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/seg491X-team36/vsn-backend/domain/services"
+)
+
+type VerificationHandlers struct {
+	VerificationService services.VerificationService
+}
+
+func (v *VerificationHandlers) EnterEmail() http.HandlerFunc {
+	return postRequestWrapper(func(ctx context.Context, req verificationEmailRequest) verificationEmailResponse {
+		// call the enter email method of the verification service
+		v.VerificationService.EnterEmail(req.Email)
+		return verificationEmailResponse{}
+	})
+}
+
+func (v *VerificationHandlers) EnterVerificationCode() http.HandlerFunc {
+	return postRequestWrapper(func(ctx context.Context, req verificationCodeRequest) verificationCodeResponse {
+		// call the enter verification code method of the verification service
+		token, err := v.VerificationService.EnterVerificationCode(req.Email, req.Code)
+
+		return verificationCodeResponse{
+			Token: token,
+			Error: errWrapper(err),
+		}
+	})
+}

--- a/vsn-backend/features/experiment/verification_handlers.go
+++ b/vsn-backend/features/experiment/verification_handlers.go
@@ -14,7 +14,7 @@ type VerificationHandlers struct {
 func (v *VerificationHandlers) EnterEmail() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, req verificationEmailRequest) verificationEmailResponse {
 		// call the enter email method of the verification service
-		v.VerificationService.EnterEmail(req.Email)
+		_ = v.VerificationService.EnterEmail(req.Email)
 		return verificationEmailResponse{}
 	})
 }

--- a/vsn-backend/features/experiment/wrapper.go
+++ b/vsn-backend/features/experiment/wrapper.go
@@ -1,0 +1,53 @@
+package experiment
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+)
+
+type experimentHandler[Request, Response any] func(ctx context.Context, req Request) Response
+
+func errWrapper(err error) *string {
+	if err != nil {
+		msg := err.Error()
+		return &msg
+	}
+	return nil
+}
+
+func postRequestWrapper[Request, Response any](
+	handler experimentHandler[Request, Response],
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// read the request body
+		data, err := io.ReadAll(r.Body)
+
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// unmarshall the request
+		var request Request
+		if err := json.Unmarshal(data, &request); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+
+		// handle the request
+		response := handler(r.Context(), request)
+
+		// marshall the response
+		data, err = json.Marshal(response)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// sucessful response
+		_, _ = w.Write(data)
+		w.WriteHeader(http.StatusOK)
+	}
+}

--- a/vsn-backend/features/experiment/wrapper_test.go
+++ b/vsn-backend/features/experiment/wrapper_test.go
@@ -1,0 +1,45 @@
+package experiment
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostWrapper(t *testing.T) {
+	type dummyRequest struct {
+		A int `json:"a"`
+		B int `json:"b"`
+	}
+
+	type dummyResponse struct {
+		C int `json:"c"`
+	}
+
+	handler := postRequestWrapper(func(ctx context.Context, req dummyRequest) dummyResponse {
+		return dummyResponse{
+			C: req.A + req.B,
+		}
+	})
+
+	t.Run("happy-path", func(t *testing.T) {
+		reqData, _ := json.Marshal(dummyRequest{A: 1, B: 2})
+		expectedResData, _ := json.Marshal(dummyResponse{C: 3})
+
+		r := httptest.NewRequest(http.MethodPost, "/", bytes.NewBuffer(reqData))
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+
+		actualResData, _ := io.ReadAll(w.Result().Body)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, expectedResData, actualResData)
+	})
+}


### PR DESCRIPTION
closes #63

- Just calls the `services.VerificationService` methods so no tests for these handlers
- Added a function to "wrap" post requests