### PR TITLE
Implement pending handler

### DIFF
--- a/vsn-backend/codegen/db/models.go
+++ b/vsn-backend/codegen/db/models.go
@@ -63,13 +63,14 @@ type Experiment struct {
 
 type ExperimentResult struct {
 	ID           uuid.UUID
+	CreatedAt    time.Time
 	UserID       uuid.UUID
 	ExperimentID uuid.UUID
-	Completed    time.Time
 }
 
 type Invite struct {
 	ID           uuid.UUID
+	CreatedAt    time.Time
 	UserID       uuid.UUID
 	ExperimentID uuid.UUID
 	Supervised   bool

--- a/vsn-backend/codegen/sql/invite.sql
+++ b/vsn-backend/codegen/sql/invite.sql
@@ -20,3 +20,8 @@ INSERT INTO
 VALUES
     ($1, $2, $3)
 RETURNING *;
+
+-- name: GetPendingInvites :many
+SELECT * FROM invites WHERE invites.user_id = $1 AND invites.experiment_id NOT IN 
+(SELECT experiment_id FROM experiment_results WHERE experiment_results.user_id = $1)
+ORDER BY invites.created_at ASC;

--- a/vsn-backend/codegen/sql/schema.sql
+++ b/vsn-backend/codegen/sql/schema.sql
@@ -15,15 +15,16 @@ CREATE TABLE experiments (
 
 CREATE TABLE experiment_results (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     user_id UUID NOT NULL,
     experiment_id UUID NOT NULL,
-    completed TIMESTAMP NOT NULL,
     CONSTRAINT fk_user FOREIGN KEY(user_id) REFERENCES users(id),
     CONSTRAINT fk_experiment FOREIGN KEY(experiment_id) REFERENCES experiments(id)
 );
 
 CREATE TABLE invites (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMP NOT NULL DEFAULT now(),
     user_id UUID NOT NULL,
     experiment_id UUID NOT NULL,
     supervised BOOLEAN NOT NULL,

--- a/vsn-backend/domain/model/domain_models.go
+++ b/vsn-backend/domain/model/domain_models.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 )
 
@@ -21,6 +23,7 @@ type User struct {
 
 type Invite struct {
 	ID           uuid.UUID
+	CreatedAt    time.Time
 	UserID       uuid.UUID
 	ExperimentID uuid.UUID
 	Supervised   bool

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -25,9 +25,9 @@ type ExperimentConfig struct {
 
 type ExperimentResult struct {
 	Id           uuid.UUID
+	CreatedAt    time.Time
 	UserId       uuid.UUID // id used to store the experiment data
 	ExperimentId uuid.UUID
-	Completed    time.Time
 }
 
 type ExperimentInput struct {

--- a/vsn-backend/domain/repository/repository.go
+++ b/vsn-backend/domain/repository/repository.go
@@ -18,6 +18,7 @@ type InviteRepository interface {
 	GetInvite(ctx context.Context, id uuid.UUID) (model.Invite, error)
 	GetInvitesByExperimentId(ctx context.Context, supervised bool, id uuid.UUID) ([]model.Invite, error)
 	CreateInvite(ctx context.Context, input model.InviteInput) (model.Invite, error)
+	GetPendingInvites(ctx context.Context, userId uuid.UUID) []model.Invite
 }
 
 type ExperimentRepository interface {

--- a/vsn-backend/features/experiment/active_experiment.go
+++ b/vsn-backend/features/experiment/active_experiment.go
@@ -1,0 +1,11 @@
+package experiment
+
+import (
+	"github.com/google/uuid"
+)
+
+type activeExperiment struct {
+	TrackingId   uuid.UUID // id used to save the results
+	ExperimentId uuid.UUID
+	UserId       uuid.UUID
+}

--- a/vsn-backend/features/experiment/active_experiment_cache.go
+++ b/vsn-backend/features/experiment/active_experiment_cache.go
@@ -1,0 +1,19 @@
+package experiment
+
+import (
+	"errors"
+
+	"github.com/google/uuid"
+)
+
+type activeExperimentCache struct {
+	experiments map[uuid.UUID]*activeExperiment
+}
+
+func (cache *activeExperimentCache) Get(userId uuid.UUID) (*activeExperiment, error) {
+	experiment, ok := cache.experiments[userId]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return experiment, nil
+}

--- a/vsn-backend/features/experiment/experiment_handlers.go
+++ b/vsn-backend/features/experiment/experiment_handlers.go
@@ -11,11 +11,11 @@ import (
 
 // ExperimentService interface required by ExperimentHandlers
 type ExperimentService interface {
-	Pending(userId uuid.UUID) pendingExperimentsResponse
-	StartExperiment(userId, experimentId uuid.UUID) startExperimentResponse
-	StartRound(userId uuid.UUID) (*model.ExperimentStatus, error)
-	StopRound(userId uuid.UUID) (*model.ExperimentStatus, error)
-	Record(userId uuid.UUID, request recordDataRequest) error
+	Pending(ctx context.Context, userId uuid.UUID) pendingExperimentsResponse
+	StartExperiment(ctx context.Context, userId, experimentId uuid.UUID) startExperimentResponse
+	StartRound(ctx context.Context, userId uuid.UUID) (*model.ExperimentStatus, error)
+	StopRound(ctx context.Context, userId uuid.UUID) (*model.ExperimentStatus, error)
+	Record(ctx context.Context, userId uuid.UUID, request recordDataRequest) error
 }
 
 type ExperimentHandlers struct {
@@ -25,21 +25,21 @@ type ExperimentHandlers struct {
 func (e *ExperimentHandlers) Pending() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, _ pendingExperimentsRequest) pendingExperimentsResponse {
 		token, _ := security.AuthToken(ctx)
-		return e.ExperimentService.Pending(token.UserId) // experiment service pending method
+		return e.ExperimentService.Pending(ctx, token.UserId) // experiment service pending method
 	})
 }
 
 func (e *ExperimentHandlers) StartExperiment() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, req startExperimentRequest) startExperimentResponse {
 		token, _ := security.AuthToken(ctx)
-		return e.ExperimentService.StartExperiment(token.UserId, req.ExperimentId) // experiment service start experiment method
+		return e.ExperimentService.StartExperiment(ctx, token.UserId, req.ExperimentId) // experiment service start experiment method
 	})
 }
 
 func (e *ExperimentHandlers) StartRound() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, req startRoundRequest) startRoundResponse {
 		token, _ := security.AuthToken(ctx)
-		status, err := e.ExperimentService.StartRound(token.UserId) // experiment service start round method
+		status, err := e.ExperimentService.StartRound(ctx, token.UserId) // experiment service start round method
 
 		return startRoundResponse{
 			Status: status,
@@ -51,7 +51,7 @@ func (e *ExperimentHandlers) StartRound() http.HandlerFunc {
 func (e *ExperimentHandlers) StopRound() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, req startRoundRequest) stopRoundResponse {
 		token, _ := security.AuthToken(ctx)
-		status, err := e.ExperimentService.StopRound(token.UserId) // experiment service stop round method
+		status, err := e.ExperimentService.StopRound(ctx, token.UserId) // experiment service stop round method
 
 		return stopRoundResponse{
 			Status: status,
@@ -63,7 +63,7 @@ func (e *ExperimentHandlers) StopRound() http.HandlerFunc {
 func (e *ExperimentHandlers) Record() http.HandlerFunc {
 	return postRequestWrapper(func(ctx context.Context, req recordDataRequest) recordDataResponse {
 		token, _ := security.AuthToken(ctx)
-		err := e.ExperimentService.Record(token.UserId, req) // experiment service record method
+		err := e.ExperimentService.Record(ctx, token.UserId, req) // experiment service record method
 
 		return recordDataResponse{
 			Error: errWrapper(err),

--- a/vsn-backend/features/experiment/service.go
+++ b/vsn-backend/features/experiment/service.go
@@ -1,0 +1,64 @@
+package experiment
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/seg491X-team36/vsn-backend/domain/model"
+)
+
+type inviteRepository interface {
+	GetPendingInvites(ctx context.Context, userId uuid.UUID) []model.Invite
+}
+
+type Service struct {
+	invites           inviteRepository
+	activeExperiments *activeExperimentCache
+}
+
+func (s *Service) Pending(ctx context.Context, userId uuid.UUID) pendingExperimentsResponse {
+	experiment, _ := s.activeExperiments.Get(userId)
+	invites := s.invites.GetPendingInvites(ctx, userId)
+
+	// there's an experiment in progress
+	if experiment != nil {
+		return pendingExperimentsResponse{
+			ExperimentId:         &experiment.ExperimentId,
+			ExperimentInProgress: true,
+			Pending:              len(invites) - 1, // the in progress experiment will be in the pending invites
+		}
+	}
+
+	// there's at least one pending experiment
+	if len(invites) > 0 {
+		return pendingExperimentsResponse{
+			ExperimentId:         &invites[0].ExperimentID,
+			ExperimentInProgress: false,
+			Pending:              len(invites),
+		}
+	}
+
+	// there are no pending experiments
+	return pendingExperimentsResponse{
+		ExperimentId:         nil,
+		ExperimentInProgress: false,
+		Pending:              len(invites), // 0
+	}
+}
+
+func (s *Service) StartExperiment(userId, experimentId uuid.UUID) startExperimentResponse {
+	return startExperimentResponse{}
+}
+
+func (s *Service) StartRound(userId uuid.UUID) (*model.ExperimentStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *Service) StopRound(userId uuid.UUID) (*model.ExperimentStatus, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (s *Service) Record(userId uuid.UUID, request recordDataRequest) error {
+	return errors.New("not implemented")
+}

--- a/vsn-backend/features/experiment/service_test.go
+++ b/vsn-backend/features/experiment/service_test.go
@@ -1,0 +1,81 @@
+package experiment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/stretchr/testify/assert"
+)
+
+type inviteRepositoryStub struct {
+	Invites []model.Invite
+}
+
+func (repository *inviteRepositoryStub) GetPendingInvites(ctx context.Context, userId uuid.UUID) []model.Invite {
+	return repository.Invites
+}
+
+func TestServicePending(t *testing.T) {
+	userId := uuid.New()
+	experimentId := uuid.New()
+
+	t.Run("in-progress", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{
+					{ExperimentID: experimentId},
+				},
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{
+					userId: {
+						UserId:       userId,
+						ExperimentId: experimentId,
+					},
+				},
+			},
+		}
+
+		res := service.Pending(context.Background(), userId)
+		assert.True(t, res.ExperimentInProgress)         // experiment is in progress
+		assert.Equal(t, experimentId, *res.ExperimentId) // experiment id is correct
+		assert.Equal(t, 0, res.Pending)                  // no pending experiments because the experiment is in progress
+	})
+
+	t.Run("not-in-progress-with-invites", func(t *testing.T) {
+		// service with no active experiment
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{
+					{ExperimentID: experimentId},
+				},
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+		}
+
+		res := service.Pending(context.Background(), userId)
+		assert.False(t, res.ExperimentInProgress)        // experiment not in progress
+		assert.Equal(t, experimentId, *res.ExperimentId) // experiment id is correct
+		assert.Equal(t, 1, res.Pending)                  // one pending experiment
+	})
+
+	t.Run("not-in-progress-without-invites", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{},
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+		}
+
+		res := service.Pending(context.Background(), userId)
+		assert.False(t, res.ExperimentInProgress) // experimennt not in progress
+		assert.Nil(t, res.ExperimentId)           // no pending experiment
+		assert.Equal(t, 0, res.Pending)           // no pending experiments
+	})
+}

--- a/vsn-backend/features/postgres/invite_repository.go
+++ b/vsn-backend/features/postgres/invite_repository.go
@@ -54,3 +54,11 @@ func (repository *InviteRepository) CreateInvite(
 	})
 	return model.Invite(invite), err
 }
+
+func (repository *InviteRepository) GetPendingInvites(ctx context.Context, userId uuid.UUID) []model.Invite {
+	invites, err := repository.Query.GetPendingInvites(ctx, userId)
+	if err != nil {
+		return []model.Invite{}
+	}
+	return convertInvites(invites)
+}

--- a/vsn-backend/features/resolvers/experiment_result.go
+++ b/vsn-backend/features/resolvers/experiment_result.go
@@ -3,6 +3,7 @@ package resolvers
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/seg491X-team36/vsn-backend/domain/model"
 )
@@ -20,4 +21,8 @@ func (r *ExperimentResultResolvers) Experiment(ctx context.Context, obj *model.E
 
 func (r *ExperimentResultResolvers) Download(ctx context.Context, obj *model.ExperimentResult) (string, error) {
 	return "", errors.New("not implemented")
+}
+
+func (r *ExperimentResultResolvers) Completed(ctx context.Context, obj *model.ExperimentResult) (time.Time, error) {
+	return obj.CreatedAt, nil
 }


### PR DESCRIPTION
closes #66 
- I added a `CreatedAt` field to our invites for sorting in queries
- I also decided to rename the `Completed` field on the `ExperimentResult` struct to `CreatedAt` for consistency. I needed to regenerate the GraphQL codegen because of this.

The logic that I added
- `GetPendingInvites` SQL query
- Implemented Pending
- placeholder `activeExperiment` struct, and the start of `activeExperimentCache` where we will store experiment progress for now.

