### PR TITLE
Dan/65 start and stop round handlers

### DIFF
--- a/vsn-backend/features/experiment/active_experiment.go
+++ b/vsn-backend/features/experiment/active_experiment.go
@@ -2,10 +2,38 @@ package experiment
 
 import (
 	"github.com/google/uuid"
+	"github.com/seg491X-team36/vsn-backend/domain/model"
 )
 
 type activeExperiment struct {
 	TrackingId   uuid.UUID // id used to save the results
 	ExperimentId uuid.UUID
 	UserId       uuid.UUID
+	model.ExperimentStatus
+	model.ExperimentConfig
+}
+
+func (ae *activeExperiment) StartRound() (model.ExperimentStatus, error) {
+	if ae.RoundInProgress {
+		return ae.ExperimentStatus, errExperimentRoundInProgress
+	}
+
+	// update round in progress and round number
+	ae.RoundInProgress = true
+	ae.RoundNumber += 1
+	return ae.ExperimentStatus, nil
+}
+
+func (ae *activeExperiment) StopRound(data experimentData) (model.ExperimentStatus, error) {
+	if !ae.RoundInProgress {
+		return ae.ExperimentStatus, errExperimentRoundNotInProgress
+	}
+	ae.Record(data) // record data
+
+	// update round in progress
+	ae.RoundInProgress = false
+	return ae.ExperimentStatus, nil
+}
+
+func (ae *activeExperiment) Record(data experimentData) {
 }

--- a/vsn-backend/features/experiment/active_experiment_cache.go
+++ b/vsn-backend/features/experiment/active_experiment_cache.go
@@ -1,8 +1,6 @@
 package experiment
 
 import (
-	"errors"
-
 	"github.com/google/uuid"
 )
 
@@ -13,7 +11,11 @@ type activeExperimentCache struct {
 func (cache *activeExperimentCache) Get(userId uuid.UUID) (*activeExperiment, error) {
 	experiment, ok := cache.experiments[userId]
 	if !ok {
-		return nil, errors.New("not found")
+		return nil, errExperimentNotFound
 	}
 	return experiment, nil
+}
+
+func (cache *activeExperimentCache) Delete(userId uuid.UUID) {
+	delete(cache.experiments, userId)
 }

--- a/vsn-backend/features/experiment/schema.go
+++ b/vsn-backend/features/experiment/schema.go
@@ -1,10 +1,17 @@
 package experiment
 
 import (
+	"errors"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/seg491X-team36/vsn-backend/domain/model"
+)
+
+var (
+	errExperimentNotFound           = errors.New("experiment not found")
+	errExperimentRoundInProgress    = errors.New("experiment round already in progress")
+	errExperimentRoundNotInProgress = errors.New("experiment round not in progress")
 )
 
 type verificationEmailRequest struct {
@@ -39,11 +46,15 @@ type startExperimentRequest struct {
 	ExperimentId uuid.UUID `json:"experimentId"` // experiment id to start
 }
 
+type startExperimentData struct {
+	Experiment model.ExperimentConfig `json:"experiment"`
+	Status     model.ExperimentStatus `json:"status"` // always present starting or resuming
+	Frame      *frame                 `json:"frame"`  // the last frame recorded. only present when resuming and continuing from last frame
+}
+
 type startExperimentResponse struct {
-	Experiment *model.ExperimentConfig `json:"experiment"`
-	Frame      *frame                  `json:"frame"`  // the last frame we recorded. only present when resuming and continuing from last frame
-	Status     *model.ExperimentStatus `json:"status"` // always present starting or resuming
-	Error      *string                 `json:"error"`
+	Data  *startExperimentData
+	Error *string `json:"error"`
 }
 
 type startRoundRequest struct {
@@ -56,7 +67,7 @@ type startRoundResponse struct {
 }
 
 type stopRoundRequest struct {
-	// no request information needed
+	Data experimentData `json:"data"` // the remaining data to ensure all data is recorded before stopping the round
 }
 
 type stopRoundResponse struct {
@@ -65,12 +76,16 @@ type stopRoundResponse struct {
 }
 
 type recordDataRequest struct {
-	Frames []frame `json:"frames"`
-	Events []event `json:"events"`
+	Data experimentData `json:"data"`
 }
 
 type recordDataResponse struct {
 	Error *string `json:"error"`
+}
+
+type experimentData struct {
+	Frames []frame `json:"frames"`
+	Events []event `json:"events"`
 }
 
 type frame struct {

--- a/vsn-backend/features/experiment/service.go
+++ b/vsn-backend/features/experiment/service.go
@@ -47,18 +47,47 @@ func (s *Service) Pending(ctx context.Context, userId uuid.UUID) pendingExperime
 	}
 }
 
-func (s *Service) StartExperiment(ctx context.Context, userId, experimentId uuid.UUID) startExperimentResponse {
-	return startExperimentResponse{}
+func (s *Service) StartExperiment(ctx context.Context, userId, experimentId uuid.UUID) (*startExperimentData, error) {
+	return nil, errors.New("not implemented")
 }
 
 func (s *Service) StartRound(ctx context.Context, userId uuid.UUID) (*model.ExperimentStatus, error) {
-	return nil, errors.New("not implemented")
+	// get the active experiment
+	experiment, err := s.activeExperiments.Get(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	// call start round
+	status, err := experiment.StartRound()
+	return &status, err
 }
 
-func (s *Service) StopRound(ctx context.Context, userId uuid.UUID) (*model.ExperimentStatus, error) {
-	return nil, errors.New("not implemented")
+func (s *Service) StopRound(ctx context.Context, userId uuid.UUID, data experimentData) (*model.ExperimentStatus, error) {
+	// get the active experiment
+	experiment, err := s.activeExperiments.Get(userId)
+	if err != nil {
+		return nil, err
+	}
+
+	// call stop round
+	status, err := experiment.StopRound(data)
+
+	// the experiment is done
+	if status.Done() {
+		s.activeExperiments.Delete(userId)
+	}
+
+	return &status, err
 }
 
-func (s *Service) Record(ctx context.Context, userId uuid.UUID, request recordDataRequest) error {
-	return errors.New("not implemented")
+func (s *Service) Record(ctx context.Context, userId uuid.UUID, data experimentData) error {
+	// get the active experiment
+	experiment, err := s.activeExperiments.Get(userId)
+	if err != nil {
+		return err
+	}
+
+	experiment.Record(data)
+	return nil
 }

--- a/vsn-backend/features/experiment/service_test.go
+++ b/vsn-backend/features/experiment/service_test.go
@@ -79,3 +79,77 @@ func TestServicePending(t *testing.T) {
 		assert.Equal(t, 0, res.Pending)           // no pending experiments
 	})
 }
+
+func TestStartAndStopRound(t *testing.T) {
+	userId1 := uuid.New()
+	userId2 := uuid.New()
+
+	experiments := &activeExperimentCache{
+		experiments: map[uuid.UUID]*activeExperiment{
+			userId1: {
+				UserId: userId1,
+				ExperimentStatus: model.ExperimentStatus{
+					RoundInProgress: false,
+					RoundNumber:     0,
+					RoundsTotal:     2,
+				},
+			},
+		},
+	}
+
+	service := &Service{
+		invites:           &inviteRepositoryStub{},
+		activeExperiments: experiments,
+	}
+
+	ctx := context.Background()
+
+	// start round for a user with no active experiments
+	status, err := service.StartRound(ctx, userId2)
+	assert.ErrorIs(t, err, errExperimentNotFound)
+	assert.Nil(t, status)
+
+	// stop round for a user with no active experiments
+	status, err = service.StopRound(ctx, userId2, experimentData{})
+	assert.ErrorIs(t, err, errExperimentNotFound)
+	assert.Nil(t, status)
+
+	// stop round for a user with round not in progress
+	status, err = service.StopRound(ctx, userId1, experimentData{})
+	assert.ErrorIs(t, err, errExperimentRoundNotInProgress)
+	assert.Equal(t, &model.ExperimentStatus{
+		RoundInProgress: false,
+		RoundNumber:     0,
+		RoundsTotal:     2,
+	}, status) // still returns the status even if the round is not stopped
+
+	for i := 1; i <= 2; i++ {
+		// start round
+		status, err = service.StartRound(ctx, userId1)
+		expected := &model.ExperimentStatus{
+			RoundInProgress: true,
+			RoundNumber:     i,
+			RoundsTotal:     2,
+		}
+		assert.NoError(t, err)
+		assert.Equal(t, expected, status)
+
+		// start round gives an error because the round is in progress
+		status, err = service.StartRound(ctx, userId1)
+		assert.Error(t, errExperimentRoundInProgress)
+		assert.Equal(t, expected, status) // status does not change
+
+		// stop round
+		status, err = service.StopRound(ctx, userId1, experimentData{})
+		assert.NoError(t, err)
+		assert.Equal(t, &model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     i,
+			RoundsTotal:     2,
+		}, status)
+	}
+
+	_, err = experiments.Get(userId1)
+	assert.Error(t, errExperimentNotFound) // the experiment was deleted
+
+}

--- a/vsn-backend/features/experiment/service_test.go
+++ b/vsn-backend/features/experiment/service_test.go
@@ -136,7 +136,7 @@ func TestStartAndStopRound(t *testing.T) {
 
 		// start round gives an error because the round is in progress
 		status, err = service.StartRound(ctx, userId1)
-		assert.Error(t, errExperimentRoundInProgress)
+		assert.ErrorIs(t, err, errExperimentRoundInProgress)
 		assert.Equal(t, expected, status) // status does not change
 
 		// stop round
@@ -150,6 +150,6 @@ func TestStartAndStopRound(t *testing.T) {
 	}
 
 	_, err = experiments.Get(userId1)
-	assert.Error(t, errExperimentNotFound) // the experiment was deleted
+	assert.ErrorIs(t, err, errExperimentNotFound) // the experiment was deleted
 
 }


### PR DESCRIPTION
closes #65
- Implement start/stop round handlers
- Updated schema so that the stop round request includes experiment data