### PR TITLE
Implement start and record handlers

### DIFF
--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -50,12 +50,12 @@ type ExperimentUpdateNameInput struct {
 if an experiment has 3 rounds the state should go:
 
 start experiment -> {"roundInProgress": false, "roundNumber": 0}
-start round -> {"roundInProgress": true, "roundNumber": 1}
+start round -> {"roundInProgress": true, "roundNumber": 0}
 stop round -> {"roundInProgress": false, "roundNumber": 1}
-start round -> {"roundInProgress": true, "roundNumber": 2}
+start round -> {"roundInProgress": true "roundNumber": 1}
 stop round -> {"roundInProgress": false, "roundNumber": 2}
-start round -> {"roundInProgress": true, "roundNumber": 3}
-stop round -> {"roundInProgress": false, "roundNumber": 3}
+start round -> {"roundInProgress": true, "roundNumber": 2}
+stop round -> {"roundInProgress": false, "roundNumber": 3} DONE
 */
 type ExperimentStatus struct {
 	RoundInProgress bool `json:"roundInProgress"`

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -17,9 +17,11 @@ type Experiment struct {
 	Id          uuid.UUID
 	Name        string
 	Description string
+	Config      ExperimentConfig
 }
 
 type ExperimentConfig struct {
+	RoundsTotal  int
 	ResumeConfig ExperimentResumeConfig
 }
 

--- a/vsn-backend/features/experiment/active_experiment.go
+++ b/vsn-backend/features/experiment/active_experiment.go
@@ -1,16 +1,58 @@
 package experiment
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"github.com/seg491X-team36/vsn-backend/domain/model"
 )
+
+type recorderMetadata struct {
+	TrackingId   uuid.UUID
+	ExperimentId uuid.UUID
+	RoundNumber  int
+}
+
+type recorder interface {
+	Record(metadata recorderMetadata, data experimentData)
+}
 
 type activeExperiment struct {
 	TrackingId   uuid.UUID // id used to save the results
 	ExperimentId uuid.UUID
 	UserId       uuid.UUID
+	recorder     recorder
+	latestFrame  *frame // track the latest frame
+
 	model.ExperimentStatus
 	model.ExperimentConfig
+}
+
+func (ae *activeExperiment) Resume() *frame {
+	/* case #1 the round must be reset and it is not in progress
+	- nothing needs to be reset */
+	if ae.ResumeConfig == model.RESET_ROUND && !ae.RoundInProgress {
+		ae.RecordEvent("RESUME:NO_EFFECT")
+		return nil
+	}
+
+	// case #2 the round must be reset and it is in progress
+	if ae.ResumeConfig == model.RESET_ROUND && ae.RoundInProgress {
+		ae.RecordEvent("RESUME:RESET_ROUND")
+		ae.RoundInProgress = false
+		return nil
+	}
+
+	// case #3 the round must be continued and it is in progress
+	if ae.ResumeConfig == model.CONTINUE_ROUND && ae.RoundInProgress {
+		ae.RecordEvent("RESUME:CONTINUE_ROUND")
+		return ae.latestFrame
+	}
+
+	/* case #4 the round must be continued but it is not in progress
+	- no frame can be returned */
+	ae.RecordEvent("RESUME:NO_EFFECT")
+	return nil
 }
 
 func (ae *activeExperiment) StartRound() (model.ExperimentStatus, error) {
@@ -18,9 +60,9 @@ func (ae *activeExperiment) StartRound() (model.ExperimentStatus, error) {
 		return ae.ExperimentStatus, errExperimentRoundInProgress
 	}
 
-	// update round in progress and round number
+	// update round in progress
+	ae.RecordEvent("ROUND:START")
 	ae.RoundInProgress = true
-	ae.RoundNumber += 1
 	return ae.ExperimentStatus, nil
 }
 
@@ -30,10 +72,29 @@ func (ae *activeExperiment) StopRound(data experimentData) (model.ExperimentStat
 	}
 	ae.Record(data) // record data
 
-	// update round in progress
+	// update round in progress and go to the next round
+	ae.RecordEvent("ROUND:STOP")
 	ae.RoundInProgress = false
+	ae.RoundNumber += 1
+	ae.latestFrame = nil // reset the latest frame
 	return ae.ExperimentStatus, nil
 }
 
 func (ae *activeExperiment) Record(data experimentData) {
+	if n := len(data.Frames); n > 0 {
+		ae.latestFrame = &data.Frames[n-1] // update the latest frame
+	}
+	meta := recorderMetadata{
+		TrackingId:   ae.TrackingId,
+		ExperimentId: ae.ExperimentId,
+		RoundNumber:  ae.RoundNumber,
+	}
+	ae.recorder.Record(meta, data)
+}
+
+func (ae *activeExperiment) RecordEvent(name string) {
+	ae.Record(experimentData{
+		Frames: []frame{},
+		Events: []event{{Name: name, Timestamp: time.Now().UTC()}},
+	})
 }

--- a/vsn-backend/features/experiment/active_experiment_cache.go
+++ b/vsn-backend/features/experiment/active_experiment_cache.go
@@ -8,6 +8,10 @@ type activeExperimentCache struct {
 	experiments map[uuid.UUID]*activeExperiment
 }
 
+func (cache *activeExperimentCache) Set(userId uuid.UUID, experiment *activeExperiment) {
+	cache.experiments[userId] = experiment
+}
+
 func (cache *activeExperimentCache) Get(userId uuid.UUID) (*activeExperiment, error) {
 	experiment, ok := cache.experiments[userId]
 	if !ok {

--- a/vsn-backend/features/experiment/active_experiment_test.go
+++ b/vsn-backend/features/experiment/active_experiment_test.go
@@ -1,0 +1,146 @@
+package experiment
+
+import (
+	"testing"
+	"time"
+
+	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResume(t *testing.T) {
+	t.Run("tc1", func(t *testing.T) {
+		// not in progress, and RESET_ROUND
+		recorder := &recorderStub{}
+		experiment := &activeExperiment{
+			recorder:    recorder,
+			latestFrame: &frame{},
+			ExperimentStatus: model.ExperimentStatus{
+				RoundInProgress: false, // NOT IN PROGRESS
+				RoundNumber:     1,
+				RoundsTotal:     2,
+			},
+			ExperimentConfig: model.ExperimentConfig{
+				RoundsTotal:  2,
+				ResumeConfig: model.RESET_ROUND, // reset round
+			},
+		}
+
+		frame := experiment.Resume()
+
+		assert.Nil(t, frame)
+		assert.Equal(t, "RESUME:NO_EFFECT", recorder.events[0].Name)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     1,
+			RoundsTotal:     2,
+		}, experiment.ExperimentStatus)
+	})
+
+	t.Run("tc2", func(t *testing.T) {
+		// in progress, and RESET_ROUND
+		recorder := &recorderStub{}
+		experiment := &activeExperiment{
+			recorder:    recorder,
+			latestFrame: &frame{},
+			ExperimentStatus: model.ExperimentStatus{
+				RoundInProgress: true,
+				RoundNumber:     1,
+				RoundsTotal:     2,
+			},
+			ExperimentConfig: model.ExperimentConfig{
+				RoundsTotal:  2,
+				ResumeConfig: model.RESET_ROUND, // reset round
+			},
+		}
+
+		frame := experiment.Resume()
+
+		assert.Nil(t, frame)
+		assert.Equal(t, "RESUME:RESET_ROUND", recorder.events[0].Name)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     1,
+			RoundsTotal:     2,
+		}, experiment.ExperimentStatus)
+	})
+
+	t.Run("tc3", func(t *testing.T) {
+		// in progress, and CONTINUE_ROUND
+		latestFrame := &frame{
+			PositionX: 1,
+			PositionY: 2,
+			PositionZ: 3,
+		}
+		recorder := &recorderStub{}
+		experiment := &activeExperiment{
+			recorder:    recorder,
+			latestFrame: latestFrame,
+			ExperimentStatus: model.ExperimentStatus{
+				RoundInProgress: true,
+				RoundNumber:     1,
+				RoundsTotal:     2,
+			},
+			ExperimentConfig: model.ExperimentConfig{
+				RoundsTotal:  2,
+				ResumeConfig: model.CONTINUE_ROUND, // continue round
+			},
+		}
+
+		frame := experiment.Resume()
+
+		assert.Equal(t, latestFrame, frame)
+		assert.Equal(t, "RESUME:CONTINUE_ROUND", recorder.events[0].Name)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: true,
+			RoundNumber:     1,
+			RoundsTotal:     2,
+		}, experiment.ExperimentStatus)
+	})
+
+	t.Run("tc4", func(t *testing.T) {
+		// not in progress, and CONTINUE_ROUND
+		recorder := &recorderStub{}
+		experiment := &activeExperiment{
+			recorder:    recorder,
+			latestFrame: &frame{},
+			ExperimentStatus: model.ExperimentStatus{
+				RoundInProgress: false,
+				RoundNumber:     1,
+				RoundsTotal:     2,
+			},
+			ExperimentConfig: model.ExperimentConfig{
+				RoundsTotal:  2,
+				ResumeConfig: model.CONTINUE_ROUND, // continue round
+			},
+		}
+
+		frame := experiment.Resume()
+
+		assert.Nil(t, frame)
+		assert.Equal(t, "RESUME:NO_EFFECT", recorder.events[0].Name)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     1,
+			RoundsTotal:     2,
+		}, experiment.ExperimentStatus)
+	})
+}
+
+func TestExperimentRecord(t *testing.T) {
+	recorder := &recorderStub{}
+	experiment := &activeExperiment{
+		recorder:    recorder,
+		latestFrame: nil,
+	}
+
+	experimentEvent := event{Name: "REWARD_FOUND", Timestamp: time.Now().UTC()}
+
+	experiment.Record(experimentData{
+		Frames: []frame{{PositionX: 1}, {PositionX: 2}}, // record 2 frames
+		Events: []event{experimentEvent},                // record 1 event
+	})
+
+	assert.Equal(t, frame{PositionX: 2}, *experiment.latestFrame) // the second frame is the latest frame
+	assert.Equal(t, experimentEvent, recorder.events[0])          // the event was recorded
+}

--- a/vsn-backend/features/experiment/service_test.go
+++ b/vsn-backend/features/experiment/service_test.go
@@ -9,12 +9,33 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type recorderStub struct {
+	events []event
+	frames []frame
+}
+
+func (r *recorderStub) Record(metadata recorderMetadata, data experimentData) {
+	r.events = append(r.events, data.Events...)
+	r.frames = append(r.frames, data.Frames...)
+}
+
 type inviteRepositoryStub struct {
+	inviteRepository
 	Invites []model.Invite
 }
 
 func (repository *inviteRepositoryStub) GetPendingInvites(ctx context.Context, userId uuid.UUID) []model.Invite {
 	return repository.Invites
+}
+
+type experimentRepositoryStub struct {
+	experimentRepository
+	Experiment model.Experiment
+	Err        error
+}
+
+func (repository *experimentRepositoryStub) GetExperiment(ctx context.Context, experimentId uuid.UUID) (model.Experiment, error) {
+	return repository.Experiment, repository.Err
 }
 
 func TestServicePending(t *testing.T) {
@@ -33,6 +54,7 @@ func TestServicePending(t *testing.T) {
 					userId: {
 						UserId:       userId,
 						ExperimentId: experimentId,
+						recorder:     &recorderStub{},
 					},
 				},
 			},
@@ -80,20 +102,24 @@ func TestServicePending(t *testing.T) {
 	})
 }
 
-func TestStartAndStopRound(t *testing.T) {
+func TestServiceStartAndStopRound(t *testing.T) {
 	userId1 := uuid.New()
 	userId2 := uuid.New()
 
+	experiment := &activeExperiment{
+		UserId: userId1,
+		ExperimentStatus: model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     0,
+			RoundsTotal:     2,
+		},
+		recorder:    &recorderStub{},
+		latestFrame: &frame{},
+	}
+
 	experiments := &activeExperimentCache{
 		experiments: map[uuid.UUID]*activeExperiment{
-			userId1: {
-				UserId: userId1,
-				ExperimentStatus: model.ExperimentStatus{
-					RoundInProgress: false,
-					RoundNumber:     0,
-					RoundsTotal:     2,
-				},
-			},
+			userId1: experiment,
 		},
 	}
 
@@ -123,7 +149,7 @@ func TestStartAndStopRound(t *testing.T) {
 		RoundsTotal:     2,
 	}, status) // still returns the status even if the round is not stopped
 
-	for i := 1; i <= 2; i++ {
+	for i := 0; i < 2; i++ {
 		// start round
 		status, err = service.StartRound(ctx, userId1)
 		expected := &model.ExperimentStatus{
@@ -144,12 +170,159 @@ func TestStartAndStopRound(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, &model.ExperimentStatus{
 			RoundInProgress: false,
-			RoundNumber:     i,
+			RoundNumber:     i + 1,
 			RoundsTotal:     2,
 		}, status)
+
+		assert.Nil(t, experiment.latestFrame) // the latest frame was reset
 	}
 
-	_, err = experiments.Get(userId1)
+	_, err = service.StartRound(ctx, userId1)
 	assert.ErrorIs(t, err, errExperimentNotFound) // the experiment was deleted
+}
 
+func TestServiceStartExperiment(t *testing.T) {
+	userId := uuid.New()
+	experimentId := uuid.New()
+
+	invite := model.Invite{
+		ID:           uuid.New(),
+		UserID:       userId,
+		ExperimentID: experimentId,
+	}
+
+	experiment := model.Experiment{
+		Id: experimentId,
+		Config: model.ExperimentConfig{
+			RoundsTotal:  2,
+			ResumeConfig: model.RESET_ROUND,
+		},
+	}
+
+	ctx := context.Background()
+
+	t.Run("happy-path", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{invite},
+			},
+			experiments: &experimentRepositoryStub{
+				Experiment: experiment,
+				Err:        nil,
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+		}
+
+		res, err := service.StartExperiment(ctx, userId, experimentId)
+
+		// return values all make sense
+		assert.NoError(t, err)
+		assert.Nil(t, res.Frame)
+		assert.Equal(t, experiment.Config, res.Experiment)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     0,
+			RoundsTotal:     2,
+		}, res.Status)
+	})
+
+	t.Run("resume-experiment", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{invite},
+			},
+			experiments: &experimentRepositoryStub{
+				Experiment: experiment,
+				Err:        nil,
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{
+					userId: {
+						recorder:     &recorderStub{},
+						latestFrame:  nil,
+						TrackingId:   uuid.New(),
+						ExperimentId: experimentId,
+						UserId:       userId,
+						ExperimentStatus: model.ExperimentStatus{
+							RoundInProgress: false,
+							RoundNumber:     1,
+							RoundsTotal:     2,
+						},
+						ExperimentConfig: experiment.Config,
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+		res, err := service.StartExperiment(ctx, userId, experimentId)
+		assert.NoError(t, err)
+		assert.Equal(t, model.ExperimentStatus{
+			RoundInProgress: false,
+			RoundNumber:     1,
+			RoundsTotal:     2,
+		}, res.Status)
+	})
+
+	t.Run("no-pending-experiments", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{},
+			},
+			experiments: &experimentRepositoryStub{
+				Experiment: experiment,
+				Err:        nil,
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+		}
+
+		_, err := service.StartExperiment(ctx, userId, experimentId)
+		assert.ErrorIs(t, err, errExperimentNotFound)
+	})
+
+	t.Run("pending-experiment-id-does-not-match", func(t *testing.T) {
+		service := &Service{
+			invites: &inviteRepositoryStub{
+				Invites: []model.Invite{invite},
+			},
+			experiments: &experimentRepositoryStub{
+				Experiment: experiment,
+				Err:        nil,
+			},
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+		}
+
+		newExperimentId := uuid.New()
+
+		_, err := service.StartExperiment(ctx, userId, newExperimentId)
+		assert.ErrorIs(t, err, errExperimentNotFound)
+	})
+}
+
+func TestServiceRecord(t *testing.T) {
+	userId := uuid.New()
+	service := &Service{
+		activeExperiments: &activeExperimentCache{
+			experiments: map[uuid.UUID]*activeExperiment{
+				userId: {
+					recorder: &recorderStub{},
+				},
+			},
+		},
+	}
+
+	// user with active experiment
+	err := service.Record(context.Background(), userId, experimentData{})
+	assert.NoError(t, err)
+
+	// user without active experiment
+	newUserId := uuid.New()
+	err = service.Record(context.Background(), newUserId, experimentData{})
+	assert.ErrorIs(t, err, errExperimentNotFound)
 }


### PR DESCRIPTION
closes #64, #82

- I implemented the start and record handlers in the same PR. I should have done two PRs but I got carried away.
- updated the start/stop round methods so that the round is incremented in stop round instead of start round. It makes recording events to the right round easier...