### PR TITLE
Add experiment synchronization

### DIFF
--- a/vsn-backend/cmd/server/main.go
+++ b/vsn-backend/cmd/server/main.go
@@ -16,7 +16,7 @@ func main() {
 
 	srv := &server.Server{
 		ExperimentHandlers: &experiment.ExperimentHandlers{
-			ExperimentService: experiment.NewService(nil, nil, recorder), // TODO
+			ExperimentService: experiment.NewService(nil, nil, nil, recorder), // TODO
 		},
 		VerificationHandlers: &experiment.VerificationHandlers{
 			// TODO

--- a/vsn-backend/features/experiment/experiment_handlers_test.go
+++ b/vsn-backend/features/experiment/experiment_handlers_test.go
@@ -61,6 +61,7 @@ func TestExperimentHandlers(t *testing.T) {
 		&experimentRepositoryStub{
 			Experiment: experiment,
 		},
+		&experimentResultRepositoryStub{},
 		recorderStubFactory(recorder),
 	)
 

--- a/vsn-backend/features/experiment/experimentsync/map.go
+++ b/vsn-backend/features/experiment/experimentsync/map.go
@@ -1,0 +1,75 @@
+package experimentsync
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+// Adapted from: https://stackoverflow.com/questions/40931373/how-to-gc-a-map-of-mutexes-in-go
+
+// Map wraps a map of mutexes.  Each key locks separately.
+type Map struct {
+	ml sync.Mutex            // lock for entry map
+	ma map[uuid.UUID]*mentry // entry map
+}
+
+type mentry struct {
+	m   *Map       // point back to M, so we can synchronize removing this mentry when cnt==0
+	el  sync.Mutex // entry-specific lock
+	cnt int        // reference count
+	key uuid.UUID  // key in ma
+}
+
+// Unlocker provides an Unlock method to release the lock.
+type Unlocker interface {
+	Unlock()
+}
+
+// New returns an initalized M.
+func NewMap() *Map {
+	return &Map{ma: make(map[uuid.UUID]*mentry)}
+}
+
+// Lock acquires a lock corresponding to this key.
+// This method will never return nil and Unlock() must be called
+// to release the lock when done.
+func (m *Map) Lock(userId uuid.UUID) Unlocker {
+
+	// read or create entry for this key atomically
+	m.ml.Lock()
+	e, ok := m.ma[userId]
+	if !ok {
+		e = &mentry{m: m, key: userId}
+		m.ma[userId] = e
+	}
+	e.cnt++ // ref count
+	m.ml.Unlock()
+
+	// acquire lock, will block here until e.cnt==1
+	e.el.Lock()
+
+	return e
+}
+
+func (me *mentry) Unlock() {
+	m := me.m
+
+	// decrement and if needed remove entry atomically
+	m.ml.Lock()
+	e, ok := m.ma[me.key]
+	if !ok { // entry must exist
+		m.ml.Unlock()
+		panic(fmt.Errorf("Unlock requested for key=%v but no entry found", me.key))
+	}
+	e.cnt--        // ref count
+	if e.cnt < 1 { // if it hits zero then we own it and remove from map
+		delete(m.ma, me.key)
+	}
+	m.ml.Unlock()
+
+	// now that map stuff is handled, we unlock and let
+	// anything else waiting on this key through
+	e.el.Unlock()
+}

--- a/vsn-backend/features/experiment/service.go
+++ b/vsn-backend/features/experiment/service.go
@@ -27,10 +27,16 @@ type Service struct {
 	recorderFactory   recorderFactory
 }
 
-func NewService(invites inviteRepository, experiments experimentRepository, factory recorderFactory) *Service {
+func NewService(
+	invites inviteRepository,
+	experiments experimentRepository,
+	experimentResults experimentResultRepository,
+	factory recorderFactory,
+) ExperimentService {
 	return &Service{
-		invites:     invites,
-		experiments: experiments,
+		invites:           invites,
+		experiments:       experiments,
+		experimentResults: experimentResults,
 		activeExperiments: &activeExperimentCache{
 			experiments: map[uuid.UUID]*activeExperiment{},
 		},

--- a/vsn-backend/features/experiment/service.go
+++ b/vsn-backend/features/experiment/service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/seg491X-team36/vsn-backend/features/experiment/experimentsync"
 )
 
 type inviteRepository interface {
@@ -33,14 +34,17 @@ func NewService(
 	experimentResults experimentResultRepository,
 	factory recorderFactory,
 ) ExperimentService {
-	return &Service{
-		invites:           invites,
-		experiments:       experiments,
-		experimentResults: experimentResults,
-		activeExperiments: &activeExperimentCache{
-			experiments: map[uuid.UUID]*activeExperiment{},
+	return &syncExperimentService{
+		Map: experimentsync.NewMap(),
+		service: &Service{
+			invites:           invites,
+			experiments:       experiments,
+			experimentResults: experimentResults,
+			activeExperiments: &activeExperimentCache{
+				experiments: map[uuid.UUID]*activeExperiment{},
+			},
+			recorderFactory: factory,
 		},
-		recorderFactory: factory,
 	}
 }
 

--- a/vsn-backend/features/experiment/service_locks.go
+++ b/vsn-backend/features/experiment/service_locks.go
@@ -1,0 +1,49 @@
+package experiment
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/seg491X-team36/vsn-backend/features/experiment/experimentsync"
+)
+
+type syncExperimentService struct {
+	*experimentsync.Map
+	service ExperimentService
+}
+
+func (s *syncExperimentService) Pending(ctx context.Context, userId uuid.UUID) pendingExperimentsResponse {
+	lock := s.Lock(userId)
+	defer lock.Unlock()
+
+	return s.service.Pending(ctx, userId)
+}
+
+func (s *syncExperimentService) StartExperiment(ctx context.Context, userId, experimentId uuid.UUID) (*startExperimentData, error) {
+	lock := s.Lock(userId)
+	defer lock.Unlock()
+
+	return s.service.StartExperiment(ctx, userId, experimentId)
+}
+
+func (s *syncExperimentService) StartRound(ctx context.Context, userId uuid.UUID) (*model.ExperimentStatus, error) {
+	lock := s.Lock(userId)
+	defer lock.Unlock()
+
+	return s.service.StartRound(ctx, userId)
+}
+
+func (s *syncExperimentService) StopRound(ctx context.Context, userId uuid.UUID, data experimentData) (*model.ExperimentStatus, error) {
+	lock := s.Lock(userId)
+	defer lock.Unlock()
+
+	return s.service.StopRound(ctx, userId, data)
+}
+
+func (s *syncExperimentService) Record(ctx context.Context, userId uuid.UUID, data experimentData) error {
+	lock := s.Lock(userId)
+	defer lock.Unlock()
+
+	return s.service.Record(ctx, userId, data)
+}


### PR DESCRIPTION
- `experimentsync.Map` stops the `ExperimentService` from executing requests from the same user in parallel