### PR TITLE
Update experiment config, add arena structs

### DIFF
--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -78,7 +78,7 @@ stop round -> {"roundInProgress": false, "roundNumber": 3} DONE
 type ExperimentStatus struct {
 	RoundInProgress bool `json:"roundInProgress"`
 	RoundsCompleted int  `json:"roundsCompleted"`
-	RoundsTotal     int  `json:"roundsTotal"` // omitted in json
+	RoundsTotal     int  `json:"roundsTotal"`
 }
 
 func NewExperimentStatus(roundsTotal int) ExperimentStatus {

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -21,7 +21,7 @@ type Experiment struct {
 }
 
 type ExperimentConfig struct {
-	RoundsTotal    int                    `json:"roundsTotal"`
+	RoundsTotal    int                    `json:"roundsTotalConfig"`
 	ResumeConfig   ExperimentResumeConfig `json:"resumeConfig"`
 	SpawnSequence  []int                  `json:"spawnSequence"`
 	RewardPosition int                    `json:"rewardPosition"`
@@ -78,7 +78,7 @@ stop round -> {"roundInProgress": false, "roundNumber": 3} DONE
 type ExperimentStatus struct {
 	RoundInProgress bool `json:"roundInProgress"`
 	RoundsCompleted int  `json:"roundsCompleted"`
-	RoundsTotal     int  `json:"-"` // omitted in json
+	RoundsTotal     int  `json:"roundsTotal"` // omitted in json
 }
 
 func NewExperimentStatus(roundsTotal int) ExperimentStatus {

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -78,7 +78,7 @@ stop round -> {"roundInProgress": false, "roundNumber": 3} DONE
 type ExperimentStatus struct {
 	RoundInProgress bool `json:"roundInProgress"`
 	RoundsCompleted int  `json:"roundsCompleted"`
-	RoundsTotal     int  `json:"roundsTotal"`
+	RoundsTotal     int  `json:"-"` // omitted in json
 }
 
 func NewExperimentStatus(roundsTotal int) ExperimentStatus {

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -21,8 +21,28 @@ type Experiment struct {
 }
 
 type ExperimentConfig struct {
-	RoundsTotal  int                    `json:"roundsTotalConfig"`
-	ResumeConfig ExperimentResumeConfig `json:"resumeConfig"`
+	RoundsTotal    int                    `json:"roundsTotal"`
+	ResumeConfig   ExperimentResumeConfig `json:"resumeConfig"`
+	SpawnSequence  []int                  `json:"spawnSequence"`
+	RewardPosition int                    `json:"rewardPosition"`
+	Arena          Arena                  `json:"arena"`
+}
+
+type Arena struct {
+	Objects         []string   `json:"objects"` // string identifier known by unity game
+	RewardPositions []Position `json:"rewardPositions"`
+	SpawnPositions  []Position `json:"spawnPositions"`
+}
+
+type ArenaObject struct {
+	Object   string   `json:"object"` // string identifier
+	Position Position `json:"position"`
+}
+
+type Position struct {
+	X float64 `json:"x"`
+	Y float64 `json:"y"`
+	Z float64 `json:"z"`
 }
 
 type ExperimentResult struct {

--- a/vsn-backend/domain/model/experiment_models.go
+++ b/vsn-backend/domain/model/experiment_models.go
@@ -21,8 +21,8 @@ type Experiment struct {
 }
 
 type ExperimentConfig struct {
-	RoundsTotal    int                    `json:"roundsTotalConfig"`
-	ResumeConfig   ExperimentResumeConfig `json:"resumeConfig"`
+	RoundsTotal    int                    `json:"roundsTotal"`
+	Resume         ExperimentResumeConfig `json:"resume"`
 	SpawnSequence  []int                  `json:"spawnSequence"`
 	RewardPosition int                    `json:"rewardPosition"`
 	Arena          Arena                  `json:"arena"`

--- a/vsn-backend/features/experiment/active_experiment.go
+++ b/vsn-backend/features/experiment/active_experiment.go
@@ -17,11 +17,11 @@ const (
 )
 
 type activeExperiment struct {
-	// id fields
+	// experiment id, config
 	ExperimentId uuid.UUID
+	Config       model.ExperimentConfig
 
-	// experiment config, status, and round information fields
-	model.ExperimentConfig
+	// experiment status, and round information fields
 	model.ExperimentStatus
 	LatestFrame *frame
 	RewardFound bool
@@ -37,7 +37,7 @@ func (ae *activeExperiment) Status() model.ExperimentStatus {
 
 func (ae *activeExperiment) StartExperimentData() *startExperimentData {
 	return &startExperimentData{
-		Config: ae.ExperimentConfig,
+		Config: ae.Config,
 		Status: ae.ExperimentStatus,
 		Frame:  ae.LatestFrame,
 	}
@@ -96,7 +96,7 @@ func (ae *activeExperiment) Resume() {
 	}
 
 	// resume and continue round
-	if ae.ResumeConfig == model.CONTINUE_ROUND {
+	if ae.Config.Resume == model.CONTINUE_ROUND {
 		ae.RecordEvent(eventResumeContinue)
 		return
 	}

--- a/vsn-backend/features/experiment/active_experiment_test.go
+++ b/vsn-backend/features/experiment/active_experiment_test.go
@@ -174,8 +174,8 @@ func TestResume(t *testing.T) {
 	t.Run("in-progress-reset", func(t *testing.T) {
 		rec := &recorderStub{}
 		experiment := &activeExperiment{
-			ExperimentConfig: model.ExperimentConfig{
-				ResumeConfig: model.RESET_ROUND,
+			Config: model.ExperimentConfig{
+				Resume: model.RESET_ROUND,
 			},
 			ExperimentStatus: model.ExperimentStatus{
 				RoundInProgress: true,
@@ -196,8 +196,8 @@ func TestResume(t *testing.T) {
 	t.Run("in-progress-continue", func(t *testing.T) {
 		rec := &recorderStub{}
 		experiment := &activeExperiment{
-			ExperimentConfig: model.ExperimentConfig{
-				ResumeConfig: model.CONTINUE_ROUND,
+			Config: model.ExperimentConfig{
+				Resume: model.CONTINUE_ROUND,
 			},
 			ExperimentStatus: model.ExperimentStatus{
 				RoundInProgress: true,

--- a/vsn-backend/features/experiment/experiment_handlers_test.go
+++ b/vsn-backend/features/experiment/experiment_handlers_test.go
@@ -49,8 +49,8 @@ func TestExperimentHandlers(t *testing.T) {
 	recorder := &recorderStub{}
 
 	experiment := model.Experiment{Id: experimentId, Config: model.ExperimentConfig{
-		RoundsTotal:  1,
-		ResumeConfig: model.CONTINUE_ROUND,
+		RoundsTotal: 1,
+		Resume:      model.CONTINUE_ROUND,
 	}}
 
 	service := NewService(

--- a/vsn-backend/features/experiment/service.go
+++ b/vsn-backend/features/experiment/service.go
@@ -105,7 +105,7 @@ func (s *Service) StartExperiment(ctx context.Context, userId, experimentId uuid
 	// create the active experiment
 	activeExperiment := &activeExperiment{
 		ExperimentId:     experimentId,
-		ExperimentConfig: experiment.Config,
+		Config:           experiment.Config,
 		ExperimentStatus: model.NewExperimentStatus(experiment.Config.RoundsTotal),
 		LatestFrame:      nil,
 		RewardFound:      false,

--- a/vsn-backend/features/experiment/service_test.go
+++ b/vsn-backend/features/experiment/service_test.go
@@ -205,8 +205,8 @@ func TestServiceStartExperiment(t *testing.T) {
 	experiment := model.Experiment{
 		Id: experimentId,
 		Config: model.ExperimentConfig{
-			RoundsTotal:  2,
-			ResumeConfig: model.RESET_ROUND,
+			RoundsTotal: 2,
+			Resume:      model.RESET_ROUND,
 		},
 	}
 
@@ -243,10 +243,10 @@ func TestServiceStartExperiment(t *testing.T) {
 				RoundsCompleted: 1,
 				RoundsTotal:     2,
 			},
-			ExperimentConfig: experiment.Config,
-			RewardFound:      false,    // reward not found
-			LatestFrame:      &frame{}, // round in progress, last frame is not nil
-			recorder:         &recorderStub{},
+			Config:      experiment.Config,
+			RewardFound: false,    // reward not found
+			LatestFrame: &frame{}, // round in progress, last frame is not nil
+			recorder:    &recorderStub{},
 		}
 
 		service := &Service{


### PR DESCRIPTION
closes #81 

- For now I'm including the full arena inside the config. It's easier and In the future arenas might get their own table in the database we don't want changes to the arena to affect the experiments.
- I'm including a "y" attribute in positions just in case

The full experiment config that will be received from the "start experiment" request looks like this:

```json
{
    "roundsTotal": 4,
    "resume": "",
    "objects": [
        {
            "object": "CUBE",
            "position": {
                "x": 0,
                "y": 0,
                "z": 0
            }
        }
    ],
    "rewardPosition": 55,
    "spawnSequence": [
        0,
        2,
        1,
        3
    ],
    "arena": {
        "objects": [
            "CUBE",
            "SPHERE",
            "PYRAMID"
        ],
        "rewardPositions": [
            {
                "x": 0,
                "y": 0,
                "z": 0
            }
        ],
        "spawnPositions": [
            {
                "x": 0,
                "y": 0,
                "z": 0
            }
        ]
    }
}
```