### PR TITLE
Implement experiment resolvers

### DIFF
--- a/vsn-backend/features/resolvers/experiment.go
+++ b/vsn-backend/features/resolvers/experiment.go
@@ -2,22 +2,31 @@ package resolvers
 
 import (
 	"context"
-	"errors"
 
 	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/seg491X-team36/vsn-backend/domain/repository"
 )
 
 type ExperimentResolvers struct {
+	repository.ExperimentResultRepository
+	repository.InviteRepository
+	repository.UserRepository
 }
 
-func (r *ExperimentResolvers) Results(ctx context.Context, obj *model.Experiment) ([]model.ExperimentResult, error) {
-	return nil, errors.New("not implemented")
+func (r *ExperimentResolvers) Results(ctx context.Context, experiment *model.Experiment) ([]model.ExperimentResult, error) {
+	// call the experiment result repository
+	results := r.ExperimentResultRepository.GetExperimentResultsByExperimentId(ctx, experiment.Id)
+	return results, nil
 }
 
-func (r *ExperimentResolvers) Pending(ctx context.Context, obj *model.Experiment) ([]model.Invite, error) {
-	return nil, errors.New("not implemented")
+func (r *ExperimentResolvers) Pending(ctx context.Context, experiment *model.Experiment) ([]model.Invite, error) {
+	// call the invites repository
+	invites := r.InviteRepository.GetPendingInvitesByExperimentId(ctx, experiment.Id)
+	return invites, nil
 }
 
-func (r *ExperimentResolvers) UsersNotInvited(ctx context.Context, obj *model.Experiment) ([]model.User, error) {
-	return nil, errors.New("not implemented")
+func (r *ExperimentResolvers) UsersNotInvited(ctx context.Context, experiment *model.Experiment) ([]model.User, error) {
+	// call the users repository
+	users := r.UserRepository.GetUsersNotInvited(ctx, experiment.Id)
+	return users, nil
 }

--- a/vsn-backend/features/resolvers/experiment_config.go
+++ b/vsn-backend/features/resolvers/experiment_config.go
@@ -2,7 +2,6 @@ package resolvers
 
 import (
 	"context"
-	"errors"
 
 	"github.com/seg491X-team36/vsn-backend/domain/model"
 )
@@ -10,10 +9,10 @@ import (
 type ExperimentConfigResolvers struct {
 }
 
-func (r *ExperimentConfigResolvers) Rounds(ctx context.Context, obj *model.ExperimentConfig) (int, error) {
-	return 0, errors.New("not implemented")
+func (r *ExperimentConfigResolvers) Rounds(ctx context.Context, config *model.ExperimentConfig) (int, error) {
+	return config.RoundsTotal, nil
 }
 
-func (r *ExperimentConfigResolvers) Resume(ctx context.Context, obj *model.ExperimentConfig) (model.ExperimentResumeConfig, error) {
-	return model.CONTINUE_ROUND, errors.New("not implemented")
+func (r *ExperimentConfigResolvers) Resume(ctx context.Context, config *model.ExperimentConfig) (model.ExperimentResumeConfig, error) {
+	return config.Resume, nil
 }

--- a/vsn-backend/features/resolvers/experiment_result.go
+++ b/vsn-backend/features/resolvers/experiment_result.go
@@ -2,18 +2,21 @@ package resolvers
 
 import (
 	"context"
-	"errors"
 
+	"github.com/google/uuid"
 	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/seg491X-team36/vsn-backend/features/dataloader"
 )
 
 type ExperimentResultResolvers struct {
+	Users       dataloader.Loader[uuid.UUID, model.User]
+	Experiments dataloader.Loader[uuid.UUID, model.Experiment]
 }
 
-func (r *ExperimentResultResolvers) User(ctx context.Context, obj *model.ExperimentResult) (model.User, error) {
-	return model.User{}, errors.New("not implemented")
+func (r *ExperimentResultResolvers) User(ctx context.Context, result *model.ExperimentResult) (model.User, error) {
+	return r.Users.Get(ctx, result.UserId)
 }
 
-func (r *ExperimentResultResolvers) Experiment(ctx context.Context, obj *model.ExperimentResult) (model.Experiment, error) {
-	return model.Experiment{}, errors.New("not implemented")
+func (r *ExperimentResultResolvers) Experiment(ctx context.Context, result *model.ExperimentResult) (model.Experiment, error) {
+	return r.Experiments.Get(ctx, result.ExperimentId)
 }


### PR DESCRIPTION
closes #91 didn't have to do anything except call the repository interfaces

Includes resolvers for `Experiment`, `ExperimentConfig`, and `ExperimentResult`