### PR TITLE
Implemented mutation resolvers

### DIFF
--- a/vsn-backend/codegen/graph/models.go
+++ b/vsn-backend/codegen/graph/models.go
@@ -13,15 +13,10 @@ type ExperimentPayload struct {
 
 type InvitePayload struct {
 	Invite *model.Invite `json:"invite"`
-	Error  string        `json:"error"`
+	Error  *string       `json:"error"`
 }
 
 type UserPayload struct {
 	User  *model.User `json:"user"`
 	Error *string     `json:"error"`
-}
-
-type UserSelectPayload struct {
-	User  *model.User `json:"user"`
-	Error string      `json:"error"`
 }

--- a/vsn-backend/codegen/schema.graphql
+++ b/vsn-backend/codegen/schema.graphql
@@ -65,7 +65,7 @@ type Query {
 type Mutation {
     # users
     userRegister(email: String!): UserPayload! 
-    userSelect(input: [UserSelectInput!]!): [UserSelectPayload!]!
+    userSelect(input: [UserSelectInput!]!): [UserPayload!]!
 
     # invites
     invite(input: [InviteInput!]!): [InvitePayload!]!
@@ -83,7 +83,7 @@ input InviteInput {
 
 type InvitePayload {
     invite: Invite
-    error: String!
+    error: String
 }
 
 type UserPayload {
@@ -94,9 +94,4 @@ type UserPayload {
 input UserSelectInput {
     userId: ID!
     accept: Boolean!
-}
-
-type UserSelectPayload {
-    user: User!
-    error: String!
 }

--- a/vsn-backend/features/resolvers/mutation.go
+++ b/vsn-backend/features/resolvers/mutation.go
@@ -2,23 +2,76 @@ package resolvers
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"sync"
 
+	"github.com/google/uuid"
 	"github.com/seg491X-team36/vsn-backend/codegen/graph"
 	"github.com/seg491X-team36/vsn-backend/domain/model"
+	"github.com/seg491X-team36/vsn-backend/domain/services"
 )
 
 type MutationResolvers struct {
+	services.UserService
+	services.InviteService
 }
 
 func (m *MutationResolvers) UserRegister(ctx context.Context, email string) (graph.UserPayload, error) {
-	return graph.UserPayload{}, errors.New("not implemented")
+	// register the user
+	user, err := payloadWrapper(m.UserService.Register(ctx, email, "MANUAL"))
+	return graph.UserPayload{User: user, Error: err}, nil
 }
 
-func (m *MutationResolvers) UserSelect(ctx context.Context, input []model.UserSelectInput) ([]graph.UserSelectPayload, error) {
-	return []graph.UserSelectPayload{}, errors.New("not implemented")
+func (m *MutationResolvers) UserSelect(ctx context.Context, input []model.UserSelectInput) ([]graph.UserPayload, error) {
+	// select users
+	selected := m.UserService.Select(ctx, input)
+
+	// index users by their id
+	selectedMap := map[uuid.UUID]model.User{}
+	for _, user := range selected {
+		selectedMap[user.Id] = user
+	}
+
+	users := make([]graph.UserPayload, len(input))
+
+	for i, selectInput := range input {
+		user, ok := selectedMap[selectInput.UserID]
+		if !ok {
+			// user was not updated
+			msg := fmt.Errorf("user not found %s", selectInput.UserID).Error()
+			users[i] = graph.UserPayload{
+				User:  nil,
+				Error: &msg,
+			}
+		} else {
+			// user was updated
+			users[i] = graph.UserPayload{
+				User:  &user,
+				Error: nil,
+			}
+		}
+	}
+
+	return users, nil
 }
 
 func (m *MutationResolvers) Invite(ctx context.Context, input []model.InviteInput) ([]graph.InvitePayload, error) {
-	return []graph.InvitePayload{}, errors.New("not implemented")
+	// results
+	invites := make([]graph.InvitePayload, len(input))
+
+	// send invites in parallel
+	wg := sync.WaitGroup{}
+
+	for i, req := range input {
+		wg.Add(1)
+		go func(j int, req model.InviteInput) {
+			invite, err := payloadWrapper(m.InviteService.Send(ctx, req))
+			invites[j] = graph.InvitePayload{Invite: invite, Error: err}
+			wg.Done()
+		}(i, req)
+	}
+
+	wg.Wait()
+
+	return invites, nil
 }

--- a/vsn-backend/features/resolvers/wrapper.go
+++ b/vsn-backend/features/resolvers/wrapper.go
@@ -1,0 +1,9 @@
+package resolvers
+
+func payloadWrapper[T any](t T, err error) (*T, *string) {
+	if err != nil {
+		msg := err.Error()
+		return nil, &msg
+	}
+	return &t, nil
+}


### PR DESCRIPTION
closes #90 
- Fixed some mistakes in the GraphQL schema (errors being non-nullable)
- `UserRegister` was straight forward
- `UserSelect` resolver needed some gross code to add error messages. Maybe we could move the logic to the user service when we implement that
- `Invite` resolver I'm running the `InviteService.Send` in parallel. Maybe we can move this to the invite service later too 